### PR TITLE
talk about max_demand in linear subscription docs

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -6,6 +6,13 @@ The format is based on [Keep a
 Changelog](https://keepachangelog.com/en/1.0.0/), and this project adheres to
 [Semantic Versioning](https://semver.org/spec/v2.0.0.html).
 
+## 0.1.1 - 2021-04-28
+
+### Changed
+
+- Changed docs in `Volley.LinearSubscription` to suggest a `:max_demand` of `1`
+  but not require it
+
 ## 0.1.0 - 2021-04-26
 
 ### Added


### PR DESCRIPTION
removes the docs talking about "you must set the max_demand to one` and replaces them with ones that suggest setting it to one and some docs that say what bad stuff could happen if you don't